### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	],
 	"type": "silverstripe-module",
 	"require": {
-		"silverstripe/cms": ">=3.1.0"
+		"silverstripe/cms": "^3.1.0"
 	},
 	"license": "BSD-2-Clause",
 	"authors": [


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.